### PR TITLE
feat: initial opengraph support for the animals page

### DIFF
--- a/src/app/components/animal-page/animal-page.component.ts
+++ b/src/app/components/animal-page/animal-page.component.ts
@@ -2,11 +2,12 @@ import { Component } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { AnimalSize, IAnimal } from '../../interfaces/animal.interface';
 import { AnimalsService } from '../../services/animals.service';
-import { Observable } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { capitalizeFirstWord, getSizeWord } from '../../utils/label-functions';
 import { FirebaseService } from '../../services/firebase.service';
+import {  OpengraphService } from '../../services/opengraph.service';
 
 @Component({
   selector: 'app-animal-page',
@@ -22,14 +23,26 @@ export class AnimalPageComponent {
   constructor(
     private route: ActivatedRoute,
     private animalsService: AnimalsService,
-    private router: Router
+    private router: Router,
+    private opengraphService: OpengraphService,
   ) {}
 
   ngOnInit(): void {
     this.route.params.subscribe((params) => {
       const animalId = params['id'];
 
-      this.animal$ = this.animalsService.getAnimalById(animalId);
+      this.animal$ = this.animalsService.getAnimalById(animalId).pipe(
+        tap(animal => {
+          if (animal) {
+            this.opengraphService.setTags([
+              { property: 'og:title', content: 'Meu Bicho Tá Salvo - POA' },
+              { property: 'og:image', content: animal.imageURLs[0] },
+              { property: 'og:description',
+                content: `${this.capitalizeFirstWord(animal.species)}, porte ${this.getSizeWord(animal.size).toLowerCase()}` }
+            ]);
+          }
+        })
+      );
     });
   }
 

--- a/src/app/interfaces/opengraph-tag.interface.ts
+++ b/src/app/interfaces/opengraph-tag.interface.ts
@@ -1,0 +1,6 @@
+export type OGProperty = 'og:title' | 'og:image' | 'og:description';
+
+export interface IOpenGraphTag {
+  property: OGProperty;
+  content: string;
+}

--- a/src/app/services/opengraph.service.spec.ts
+++ b/src/app/services/opengraph.service.spec.ts
@@ -1,0 +1,29 @@
+import { Meta } from '@angular/platform-browser';
+import { OpengraphService } from "./opengraph.service";
+import { IOpenGraphTag } from '../interfaces/opengraph-tag.interface';
+
+describe('OpengraphService', () => {
+  let service: OpengraphService;
+  let meta: Meta;
+
+  beforeEach(() => {
+    meta = new Meta(document);
+    service = new OpengraphService(meta);
+  });
+
+  it('should set meta tags', () => {
+    const tags: IOpenGraphTag[] = [
+      { property: 'og:title', content: 'Title' },
+      { property: 'og:description', content: 'Description' },
+    ];
+
+    const spy = spyOn(meta, 'addTag');
+
+    service.setTags(tags);
+
+    expect(spy.calls.count()).toEqual(2);
+    expect(spy.calls.argsFor(0)).toEqual([{ property: 'og:title', content: 'Title' }]);
+    expect(spy.calls.argsFor(1)).toEqual([{ property: 'og:description', content: 'Description' }]);
+  });
+
+});

--- a/src/app/services/opengraph.service.ts
+++ b/src/app/services/opengraph.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core";
+import { Meta } from "@angular/platform-browser";
+import { IOpenGraphTag } from "../interfaces/opengraph-tag.interface";
+
+@Injectable({
+  providedIn: 'root',
+})
+
+export class OpengraphService {
+  constructor(private meta: Meta) {}
+
+  public setTags(tags: IOpenGraphTag[]) {
+    tags.forEach((tag: IOpenGraphTag) => {
+      this.meta.addTag({property: tag.property, content: tag.content});
+    })
+  }
+}


### PR DESCRIPTION
Adds a preliminar support for Open Graph previews when sharing links on the animals  page.

The preview uses the following format:

- Title: Meu Bicho Tá Salvo - POA
- Image: first image returned from the API
- Description: [Species], porte [size]. Ex.: Cachorro, porte grande.

Note: some image previews could not work. To make it consistent, we should generate a variant of the image we would like to use with a fixed size and then, add this information in the Open Graph tags. 